### PR TITLE
Use unless-stopped restart option instead of on-failure

### DIFF
--- a/check.py
+++ b/check.py
@@ -342,7 +342,7 @@ class StructureValidator(BaseValidator):
                         f'required option {opt} not in {path} for container {container}',
                     )
 
-                self._error('restart' in container_conf and container_conf['restart'] == 'on-failure', f'restart option in {path} for container {container} must be equal to "on-failure"')
+                self._error('restart' in container_conf and container_conf['restart'] == 'unless-stopped', f'restart option in {path} for container {container} must be equal to "unless-stopped"')
 
                 for opt in container_conf:
                     self._error(

--- a/services/example/docker-compose.yml
+++ b/services/example/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.4"
 services:
   example:
-    restart: on-failure
+    restart: unless-stopped
     build: .
     pids_limit: 256
     mem_limit: 64M
@@ -13,7 +13,7 @@ services:
 
   cleaner:
     image: c4tbuts4d/dedcleaner:latest
-    restart: on-failure
+    restart: unless-stopped
     volumes:
       - "./notes:/notes"
     environment:


### PR DESCRIPTION
We should use unless-stopped restart option instead of on-failure as some processes might fail with 0 return code.